### PR TITLE
Add root endpoint to .NET snippet

### DIFF
--- a/dotnet/Program.cs
+++ b/dotnet/Program.cs
@@ -22,6 +22,9 @@ builder.Logging.AddConsole(options =>
 
 var app = builder.Build();
 
+// Add root endpoint
+app.MapGet("/", () => "Custom handler is ready and running.");
+
 // Add health check endpoint
 app.MapGet("/api/healthz", () => "Healthy");
 


### PR DESCRIPTION
The Function host pings the root to see if the custom handler is running, so adding that endpoint so it doesn't return 404. 